### PR TITLE
fix: allow for enum in typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,9 @@ module.exports = {
     'no-duplicate-imports': ['error'],
 
     // Cannot shadow names
-    '@typescript-eslint/no-shadow': ['error'],
+    // note you must disable the base rule as it can report incorrect errors
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": ["error"],
 
     // Required spacing in property declarations (copied from TSLint, defaults are good)
     'key-spacing': ['error'],


### PR DESCRIPTION
In order to use enums in typescript with the raw eslint config, you have to delete the base `no-shadow` requirement.

See [here](https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope)