### PR TITLE
fix prettier and eslint indentation clash

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,8 +37,8 @@ module.exports = {
 
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
-    // 2 space indentation
-    '@typescript-eslint/indent': ['error', 2],
+    // Use prettier indentation rules as opposed to eslint
+    '@typescript-eslint/indent': 'off',
 
     // Style
     quotes: ['error', 'single', { avoidEscape: true }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,9 +37,6 @@ module.exports = {
 
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
-    // Use prettier indentation rules as opposed to eslint
-    '@typescript-eslint/indent': 'off',
-
     // Style
     quotes: ['error', 'single', { avoidEscape: true }],
 


### PR DESCRIPTION
Changes `.eslintrc.js` to set `@typescript-eslint/indent` as `off` since it clashes with prettier's indent configuration. 

(not sure why this isn't caught with `eslint-config-prettier`, but I think it's since this is a `@typescript-eslint/indent` rule as opposed to just an `indent` rule)