### PR TITLE
fix: fixed error when running yarn start

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -28,7 +28,7 @@ module.exports = merge(common, {
   },
   devtool: 'inline-source-map',
   devServer: {
-    contentBase: './dist',
+    static: './dist',
     historyApiFallback: true,
     hot: true,
     port: 3000,


### PR DESCRIPTION
I created a new learning lab repo from the template, but when I ran yarn start it gave me an error saying that "contentBase is an unknown property". Apparently this has been renamed to the property "static", and when I changed the code to this, it fixed the error. I haven't looked into it that much though, so I'm not sure if this is definitely the correct fix for what you guys intended

These are the links I read:
https://gist.github.com/johnrichardrinehart/c8ec6ab1e60f39fc3b8dc738db649ec0
https://github.com/webpack/webpack-dev-server/issues/2958#issuecomment-757141969
https://stackoverflow.com/questions/67926476/webpack-dev-server-config-contentbase-not-working-in-latest-version
https://stackoverflow.com/questions/70309830/webpack-dev-server-config-contentbase-not-working